### PR TITLE
[feature] add proxy_protocol support

### DIFF
--- a/ngx_http_yunsuo_module.c
+++ b/ngx_http_yunsuo_module.c
@@ -30,6 +30,13 @@ void* hMod;
 HMODULE hMod;
 #endif
 
+typedef struct {
+	ngx_flag_t  on;
+} ngx_http_yunsuo_loc_conf_t;
+
+static void *ngx_http_yunsuo_create_loc_conf(ngx_conf_t *cf);
+static char *ngx_http_yunsuo_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child);
+
 int use_ngx_plugin = 0;
 
 typedef void (*frame_init_pt)();
@@ -749,6 +756,13 @@ static ngx_int_t ngx_http_yunsuo_filter_init(ngx_conf_t *cf)
 
 static ngx_command_t  ngx_http_yunsuo_commands[] = 
 {
+	{ ngx_string("yunsuo"),
+	  NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+	  ngx_conf_set_flag_slot,
+	  NGX_HTTP_LOC_CONF_OFFSET,
+	  offsetof(ngx_http_yunsuo_loc_conf_t, on),
+	  NULL },
+	
 	ngx_null_command
 };
 
@@ -760,9 +774,32 @@ static ngx_http_module_t  ngx_http_yunsuo_module_ctx =
 	NULL,                                  /* init main configuration */
 	NULL,                                  /* create server configuration */
 	NULL,                                  /* merge server configuration */
-	NULL,          /* create location configuration */
-	NULL	/* merge location configuration */
+	ngx_http_yunsuo_create_loc_conf,          /* create location configuration */
+	ngx_http_yunsuo_merge_loc_conf	/* merge location configuration */
 };
+
+static void *
+ngx_http_yunsuo_create_loc_conf(ngx_conf_t *cf)
+{
+	ngx_http_yunsuo_loc_conf_t *conf;
+	conf = ngx_pcalloc(cf->pool, sizeof(ngx_http_yunsuo_loc_conf_t));
+    if (conf == NULL) {
+        return NULL;
+    }
+	conf->on = NGX_CONF_UNSET;
+	return conf;
+}
+
+static char *
+ngx_http_yunsuo_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
+{
+	ngx_http_yunsuo_loc_conf_t  *prev = parent;
+    ngx_http_yunsuo_loc_conf_t  *conf = child;
+
+	ngx_conf_merge_value(conf->on, prev->on, 0);
+
+	return NGX_CONF_OK;
+}
 
 
 ngx_module_t  ngx_http_yunsuo_module = {
@@ -791,7 +828,12 @@ static ngx_int_t ngx_http_yunsuo_header_filter(ngx_http_request_t *r)
 	{
 		return ngx_http_next_header_filter(r);
 	}	
-	response_header_check(r);
+	ngx_http_yunsuo_loc_conf_t  *lcf;
+	lcf = ngx_http_get_module_loc_conf(r, ngx_http_yunsuo_module);
+	if (lcf->on)
+	{
+	    response_header_check(r);
+	}
 	return ngx_http_next_header_filter(r);	
 }
 
@@ -804,7 +846,11 @@ static ngx_int_t ngx_http_yunsuo_body_filter(ngx_http_request_t *r, ngx_chain_t 
 		return ngx_http_next_body_filter(r, *dpIn);
 	}	
 
-	response_body_check(r, (void**)dpIn);
+	ngx_http_yunsuo_loc_conf_t  *lcf;
+	lcf = ngx_http_get_module_loc_conf(r, ngx_http_yunsuo_module);
+	if (lcf->on){
+		response_body_check(r, (void**)dpIn);
+	}
 	return ngx_http_next_body_filter(r, *dpIn);
 }
 
@@ -820,7 +866,13 @@ int ngx_http_yunsuo_post_in_handler(ngx_http_request_t *r)
 		return 0;
 	}	
 
-	return post_in_check(r, NULL);
+	ngx_http_yunsuo_loc_conf_t  *lcf;
+	lcf = ngx_http_get_module_loc_conf(r, ngx_http_yunsuo_module);
+	if (lcf->on)
+	{
+		return post_in_check(r, NULL);
+	}
+	return 0;
 }
 
 static ngx_int_t ngx_http_yunsuo_handler(ngx_http_request_t *r)
@@ -842,6 +894,12 @@ static ngx_int_t ngx_http_yunsuo_handler(ngx_http_request_t *r)
 		return NGX_DECLINED; 
 	}
 
-	return request_check(r, r->method);       
+	gx_http_yunsuo_loc_conf_t  *lcf;
+	lcf = ngx_http_get_module_loc_conf(r, ngx_http_yunsuo_module);
+	if (lcf->on)
+	{
+		return request_check(r, r->method);
+	}
+	return NGX_DECLINED;       
 }
 

--- a/ngx_http_yunsuo_module.c
+++ b/ngx_http_yunsuo_module.c
@@ -546,7 +546,14 @@ void get_request_or_response_data_handler(void *request, void *data, int data_ty
 	{
 		if (r->connection && r->connection->addr_text.data)
 		{
-			store_data_by_type("Remote-Ip", 9, (char*)r->connection->addr_text.data, r->connection->addr_text.len, data, 0);
+			if ((0 == r->headers_in.x_forwarded_for.nelts) && (r->connection->proxy_protocol_addr.len != 0))
+			{
+				store_data_by_type("Remote-Ip", 9, (char*)(r->connection->proxy_protocol_addr.data), r->connection->proxy_protocol_addr.len, data, 0);
+			}
+			else
+			{
+				store_data_by_type("Remote-Ip", 9, (char*)r->connection->addr_text.data, r->connection->addr_text.len, data, 0);
+			}
 		}
 
 		if (r->connection && r->connection->listening && r->connection->listening->addr_text.data)


### PR DESCRIPTION
With the PROXY protocol, NGINX can learn the originating IP address even in a complex network environment, such as load balancing, etc. https://docs.nginx.com/nginx/admin-guide/load-balancer/using-proxy-protocol/

This PR supports yunsuo to get originating IP address correctly when NGINX is configured to accept the PROXY Protocol.